### PR TITLE
Add pinning and drag-and-drop ordering for ideals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,12 @@
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
 }
 
+/* Drag and Drop Highlight */
+.drag-over {
+    outline: 3px dashed rgba(99, 102, 241, 0.45);
+    outline-offset: 6px;
+}
+
 /* Progress Bar Animation */
 @keyframes progress-bar-stripes {
     from {

--- a/index.html
+++ b/index.html
@@ -235,6 +235,18 @@
             </div>
             
             <div class="p-6">
+                <!-- Pin Status -->
+                <div class="mb-6 p-4 bg-yellow-50 rounded-lg flex items-center justify-between">
+                    <div class="flex items-center space-x-3 text-gray-700">
+                        <i class="fas fa-thumbtack text-yellow-500"></i>
+                        <span class="font-medium">一覧でこの理想をピン留め</span>
+                    </div>
+                    <button type="button" id="pinToggleBtn" class="flex items-center space-x-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-yellow-100 transition-colors" title="ピン留めする">
+                        <i class="fas fa-thumbtack"></i>
+                        <span>ピン留めする</span>
+                    </button>
+                </div>
+
                 <!-- Achievement Status -->
                 <div class="mb-6 p-4 bg-gray-50 rounded-lg">
                     <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- 本質的理想カードにピン留めボタンとハイライトを追加し、Firestoreへピン状態を保存できるようにしました
- 一覧のカードをドラッグ＆ドロップで並び替えて表示順序を更新できるようにし、orderフィールドをバッチ更新する処理を追加しました
- 理想の詳細モーダルにピン留め切り替えボタンを設け、ピン留めの状態を即座に確認・変更できるようにしました

## Testing
- テストは実行していません（スイート未提供）

------
https://chatgpt.com/codex/tasks/task_e_68d567072ff0832c97f90221e06952c9